### PR TITLE
Fix race from pausing persistor

### DIFF
--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -42,11 +42,12 @@ export default function createPersistor (store, config) {
     })
 
     lastState = state
+    const len = storesToProcess.length
 
     // time iterator (read: debounce)
     if (timeIterator === null) {
       timeIterator = setInterval(() => {
-        if (storesToProcess.length === 0) {
+        if ((paused && len === storesToProcess.length) || storesToProcess.length === 0) {
           clearInterval(timeIterator)
           timeIterator = null
           return


### PR DESCRIPTION
Pulling in this fix: https://github.com/rt2zz/redux-persist/pull/454

Currently there is about a 15 second delay after logging in before viewer actually gets persisted.  Seems to be from a race condition caused by pausing persistence.  This guy fixed it, but our fork is behind the fix.